### PR TITLE
flow-library теперь является подпроектом

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "flow-library"]
+	path = flow-library
+	url = git@github.com:sno-mephi/flow-library.git

--- a/build.gradle
+++ b/build.gradle
@@ -14,10 +14,10 @@ java {
 
 repositories {
 	mavenCentral()
-	maven { url 'https://jitpack.io' }
 }
 
 dependencies {
+	implementation 'org.slf4j:slf4j-simple:2.0.9'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.postgresql:postgresql:42.6.0'
@@ -39,9 +39,7 @@ dependencies {
 	implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3'
 	implementation "org.jetbrains.kotlin:kotlin-reflect:1.9.10"
 
-	implementation('com.github.sno-mephi:flow-library:2.0.0-stable') {
-		exclude group: 'org.slf4j', module: 'slf4j-simple'
-	}
+	implementation project(':flow-library')
 }
 
 jar {
@@ -50,8 +48,4 @@ jar {
 
 bootJar {
 	archiveFileName = (System.getenv('BOT_APPLICATION_NAME') ?: 'bot-template-app').concat(".jar")
-}
-
-tasks.named('test') {
-	useJUnitPlatform()
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,3 @@
 rootProject.name = 'snomephi_bot'
+
+include 'flow-library'

--- a/src/main/java/ru/idfedorov09/telegram/bot/controller/UpdatesController.kt
+++ b/src/main/java/ru/idfedorov09/telegram/bot/controller/UpdatesController.kt
@@ -35,6 +35,7 @@ class UpdatesController : UpdatesSender(), UpdatesHandler {
         flowBuilder.initAndRun(
             flowContext = flowContext,
             dispatcher = Dispatchers.Default,
+            wait = true,
             ExpContainer(), // экспы
             telegramBot,
             update,


### PR DESCRIPTION
Теперь `flow-library` является подпроектом, и это намного удобнее - если будут происходить беды с графом, можно сразу нырять во `flow-library` и шаманить там.
Подключить подмодули можно так:
```bash
git submodule update --init --recursive
```
Клонирование репозитория теперь происходит при помощи следующей команды:
```bash
git clone --recurse-submodules git@github.com:sno-mephi/snomephi_bot.git
```
(вместо ssh может быть и http, что не рекомендуется)